### PR TITLE
gluon-ssid-changer: Fix support for batctl 2016.4

### DIFF
--- a/gluon-ssid-changer/files/usr/lib/ssid-changer/ssid-changer.sh
+++ b/gluon-ssid-changer/files/usr/lib/ssid-changer/ssid-changer.sh
@@ -21,7 +21,7 @@ else
 fi
 
 #Is there an active Gateway?
-GATEWAY_TQ=`batctl gwl | grep "^=>" | awk -F'[()]' '{print $2}'| tr -d " "` #Grep the Connection Quality of the Gateway which is currently used
+GATEWAY_TQ=`batctl gwl | grep -e "^=>" -e "^\*" | awk -F'[()]' '{print $2}'| tr -d " "` #Grep the Connection Quality of the Gateway which is currently used
 
 if [ ! $GATEWAY_TQ ]; #If there is no gateway there will be errors in the following if clauses
 then


### PR DESCRIPTION
The batman-adv/batctl 2016.4 release switched from debugfs to netlink as its primary way to retrieve information from the kernel module. This change had differently implications to the output format of batctl.

Also some cosmetic changes (like for example in the output for gwl) were done at the same time to make everything more consistent. This seemed to be the right point for doing these because many other things changed anyway.

Scripts which try to parse the output directly from batctl instead of using netlink have to be adjusted to continue to work. The parser for the selected gateway in this script has therefore to be modified to also search for the string "*" (common marker for selected entries in all outputs) instead of only for "=>".